### PR TITLE
Remove dep override after `cosmiconfig` v8.3.4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
     },
     "dependencies": {
         "@percy/cli": "^1.15.0"
-    },
-    "overrides": {
-        "cosmiconfig": "8.2.0"
     }
 }


### PR DESCRIPTION
### Description
We originally overrode `cosmiconfig` version due to https://github.com/cosmiconfig/cosmiconfig/issues/323. This issue has since been fixed in https://github.com/cosmiconfig/cosmiconfig/releases/tag/cosmiconfig-v8.3.4 so we no longer need the pin