### PR TITLE
Add Percy quota exceeded handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "node": ">=14"
     },
     "dependencies": {
-        "@percy/cli": "^1.28.7"
+        "@percy/cli": "^1.30.1"
     }
 }

--- a/src/Codeception/Module/Percy.php
+++ b/src/Codeception/Module/Percy.php
@@ -9,6 +9,7 @@ use Codeception\Module;
 use Codeception\Module\Percy\ConfigManagement;
 use Codeception\Module\Percy\Definitions;
 use Codeception\Module\Percy\Exception\PercyDisabledException;
+use Codeception\Module\Percy\Exception\PercyQuotaExceededException;
 use Codeception\Module\Percy\Output;
 use Codeception\Module\Percy\ProcessManagement;
 use Codeception\Module\Percy\ServiceContainer;
@@ -164,8 +165,8 @@ class Percy extends Module
      */
     private function onError(Throwable $exception): void
     {
-        // Always error silently if it's a "Percy disabled" exception
-        if ($exception instanceof PercyDisabledException) {
+        // Always error silently if it's a "Percy disabled" exception or "quota exceeded" exception
+        if ($exception instanceof PercyDisabledException || $exception instanceof PercyQuotaExceededException) {
             $this->output->debug($exception);
 
             return;

--- a/src/Codeception/Module/Percy/Command/ProcessSnapshots.php
+++ b/src/Codeception/Module/Percy/Command/ProcessSnapshots.php
@@ -10,6 +10,7 @@ use Codeception\Lib\Console\Output;
 use Codeception\Module\Percy\ConfigManagement;
 use Codeception\Module\Percy\Definitions;
 use Codeception\Module\Percy\Exception\PercyDisabledException;
+use Codeception\Module\Percy\Exception\PercyQuotaExceededException;
 use Codeception\Module\Percy\Output as PercyOutput;
 use Codeception\Module\Percy\ServiceContainer;
 use Codeception\Util\Debug;
@@ -108,8 +109,8 @@ class ProcessSnapshots extends Command implements CustomCommandInterface
         PercyOutput $outputService,
         ConfigManagement $configManagement
     ): int {
-        // Always error silently if it's a "Percy disabled" exception
-        if ($exception instanceof PercyDisabledException) {
+        // Always error silently if it's a "Percy disabled" exception or "quota exceeded" exception
+        if ($exception instanceof PercyDisabledException  || $exception instanceof PercyQuotaExceededException) {
             $outputService->debug($exception);
 
             return self::SUCCESS;

--- a/src/Codeception/Module/Percy/Exception/PercyQuotaExceededException.php
+++ b/src/Codeception/Module/Percy/Exception/PercyQuotaExceededException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Percy\Exception;
+
+final class PercyQuotaExceededException extends AbstractException
+{
+    //
+}

--- a/src/Codeception/Module/Percy/SnapshotManagement.php
+++ b/src/Codeception/Module/Percy/SnapshotManagement.php
@@ -69,6 +69,7 @@ class SnapshotManagement
      * @throws \Codeception\Module\Percy\Exception\StorageException
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \JsonException
+     * @throws \Codeception\Module\Percy\Exception\PercyQuotaExceededException
      */
     public function sendAll(): void
     {
@@ -82,6 +83,7 @@ class SnapshotManagement
      * @throws \Codeception\Module\Percy\Exception\StorageException
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \JsonException
+     * @throws \Codeception\Module\Percy\Exception\PercyQuotaExceededException
      */
     public function sendInstance(string $instanceId = null): void
     {


### PR DESCRIPTION
### Description
This PR handles a quota exceeded exception which can be thrown from the Percy CLI if the account has reached limits. Until there's a further use case, we now silently error in this scenario.

This also bumps the min Percy CLI version