### PR TITLE
Fix failing release tests due to PHPStan error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 7.4, 8.0, 8.1, 8.2 ]
+                php: [ 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
             fail-fast: false
         steps:
             -   name: Checkout
@@ -34,7 +34,7 @@ jobs:
             -   name: Init composer dependencies
                 run: composer update
             -   name: Install dependencies (Codeception v4)
-                run: composer update codeception/codeception:^4.0 codeception/module-webdriver codeception/module-phpbrowser -W
+                run: composer update codeception/codeception:^4.0 codeception/module-webdriver codeception/module-phpbrowser codeception/module-asserts -W
             -   name: Setup Firefox
                 uses: browser-actions/setup-firefox@latest
             -   name: Run test suite (Codeception v4)
@@ -42,10 +42,10 @@ jobs:
                     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
                 run: composer run test
             -   name: Install dependencies (Codeception v5)
-                run: composer update codeception/codeception:^5.0 codeception/module-webdriver codeception/module-phpbrowser -W
-                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2'
+                run: composer update codeception/codeception:^5.0 codeception/module-webdriver codeception/module-phpbrowser codeception/module-asserts -W
+                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3' || matrix.php == '8.4'
             -   name: Run test suite (Codeception v5)
                 env:
                     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
                 run: composer run test
-                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2'
+                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3' || matrix.php == '8.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
+                php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
             fail-fast: false
         steps:
             -   name: Checkout
@@ -43,9 +43,9 @@ jobs:
                 run: composer run test
             -   name: Install dependencies (Codeception v5)
                 run: composer update codeception/codeception:^5.0 codeception/module-webdriver codeception/module-phpbrowser codeception/module-asserts -W
-                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3' || matrix.php == '8.4'
+                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3'
             -   name: Run test suite (Codeception v5)
                 env:
                     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
                 run: composer run test
-                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3' || matrix.php == '8.4'
+                if: matrix.php == '8.0' || matrix.php == '8.1' || matrix.php == '8.2' || matrix.php == '8.3'

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     },
     "require-dev": {
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0",
-        "codeception/module-asserts": "^2.0",
-        "codeception/module-phpbrowser": "^2.0",
+        "codeception/module-asserts": "^2.0||^3.0",
+        "codeception/module-phpbrowser": "^2.0||^3.0",
         "friendsofphp/php-cs-fixer": "^3.59",
         "phpstan/phpstan": "^1.11",
         "rector/rector": "^1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "node": ">=14"
     },
     "dependencies": {
-        "@percy/cli": "^1.30.1"
+        "@percy/cli": "^1.30.2"
     }
 }

--- a/src/Codeception/Module/Percy/Serializer.php
+++ b/src/Codeception/Module/Percy/Serializer.php
@@ -25,6 +25,9 @@ class Serializer
      */
     public function unserialize(string $data): array
     {
-        return (array) json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        /** @var array<string, mixed> $result */
+        $result = (array) json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+
+        return $result;
     }
 }


### PR DESCRIPTION
### Description

This PR fixes the following error:
```
Method Codeception\Module\Percy\Serializer::unserialize() should return array<string, mixed> but returns array
```
which began erroring after a bump in PHPStan package version on install